### PR TITLE
fix vignette build--unable to find bib file

### DIFF
--- a/inst/vignettes
+++ b/inst/vignettes
@@ -1,0 +1,1 @@
+../vignettes


### PR DESCRIPTION
The bibliography and other files need to be in
the `inst` directory in order to end up installing.